### PR TITLE
deps: update build-time dependencies to current majors

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.8",
-		"@types/node": "^17.0.5",
-		"builtin-modules": "^3.2.0",
+		"@types/node": "24.13.3",
+		"builtin-modules": "5.3.0",
 		"esbuild": "0.28.2",
 		"obsidian": "^1.13.1",
 		"tslib": "^2.3.1",
-		"typescript": "^4.5.4"
+		"typescript": "5.9.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: 2.5.8
         version: 2.5.8
       '@types/node':
-        specifier: ^17.0.5
-        version: 17.0.45
+        specifier: 24.13.3
+        version: 24.13.3
       builtin-modules:
-        specifier: ^3.2.0
-        version: 3.3.0
+        specifier: 5.3.0
+        version: 5.3.0
       esbuild:
         specifier: 0.28.2
         version: 0.28.2
@@ -27,8 +27,8 @@ importers:
         specifier: ^2.3.1
         version: 2.8.1
       typescript:
-        specifier: ^4.5.4
-        version: 4.9.5
+        specifier: 5.9.3
+        version: 5.9.3
 
 packages:
 
@@ -260,15 +260,15 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@17.0.45':
-    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/tern@0.23.9':
     resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
 
-  builtin-modules@3.3.0:
-    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
-    engines: {node: '>=6'}
+  builtin-modules@5.3.0:
+    resolution: {integrity: sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==}
+    engines: {node: '>=18.20'}
 
   crelt@1.0.7:
     resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
@@ -293,10 +293,13 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
@@ -435,13 +438,15 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/node@17.0.45': {}
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
 
   '@types/tern@0.23.9':
     dependencies:
       '@types/estree': 1.0.9
 
-  builtin-modules@3.3.0: {}
+  builtin-modules@5.3.0: {}
 
   crelt@1.0.7: {}
 
@@ -487,6 +492,8 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@4.9.5: {}
+  typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}
 
   w3c-keyname@2.2.8: {}


### PR DESCRIPTION
Manual replacement for the part of Dependabot's npm-major group that is safe to take now:

- -		"@types/node": "^17.0.5",	-		"builtin-modules": "^3.2.0",
- +		"@types/node": "24.13.3",	+		"builtin-modules": "5.3.0",
- -		"typescript": "^4.5.4"	+		"typescript": "5.9.3"

Deliberately **not** taken (and to be excluded from Dependabot in a follow-up):
- `typescript` 7.x — the Go-based rewrite; staying on 5.x
- `@types/node` 26 — pinned to the Node major we actually run (24)
- `electron` 43 — kept on 39.x to match the Electron bundled in current Obsidian, which is what the e2e tests emulate

`pnpm build` / `pnpm lint` pass locally; `tsc --noEmit` error count unchanged (pre-existing, not in CI). All pins exact.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8