### PR TITLE
ci: stop Dependabot proposing majors we pin on purpose

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,17 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    # Majors we bump by hand, on purpose:
+    ignore:
+      # 7.x is the Go-based rewrite (tsgo); stay on the 5.x line until tooling catches up.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
+      # Must match the Node major we run (mise.toml), not the newest available.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      # Must match the Electron bundled in current Obsidian, which the e2e tests emulate.
+      - dependency-name: electron
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         update-types:


### PR DESCRIPTION
Adds `ignore` rules (semver-major only) for three packages whose major is a deliberate choice, not a staleness signal:

- **typescript** — 7.x is the Go-based rewrite; we stay on 5.x until the toolchain (esbuild/svelte/biome integrations) is ready
- **@types/node** — must match the Node major in `mise.toml` (24), not the newest on npm
- **electron** — must match the Electron bundled in the Obsidian build the e2e tests emulate (39.x today)

Minor/patch updates for all three still come through the `npm-minor-patch` group. Together with the deps PR this brings the open Dependabot PR count to zero.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8