### PR TITLE
ci: run lint in CI (and build on every PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: ci
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          version: 2026.8.3
+          install: true
+          cache: true
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm build


### PR DESCRIPTION
Lint (Biome) was not enforced in any CI, and this repo had **no PR-triggered CI at all** — only the release workflow on main. Now every PR and push to main runs `pnpm install --frozen-lockfile` → `pnpm lint` → `pnpm build`.

Motivation beyond style: a package.json with leftover merge-conflict markers made it into a PR branch earlier today (caught by CI only in repos that had one). `--frozen-lockfile` install and Biome fail fast on that.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8