### PR TITLE
ci: generate GitHub release notes on release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,11 @@
+# Shapes the notes that action-gh-release generates (generate_release_notes: true).
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 changelog:
   exclude:
-    labels:
-      - tagpr
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    - title: Changes
+      labels:
+        - "*"

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -43,4 +43,6 @@ jobs:
             main.js
             manifest.json
           tag_name: ${{ needs.tagpr.outputs.tagpr-tag }}
+          # GitHub-generated notes: merged PRs by category (.github/release.yml), contributors, compare link.
+          generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release bodies were empty: tagpr only creates the tag (`release = false`) and the `release` job uploaded assets without a body.

## What
- `generate_release_notes: true` on `softprops/action-gh-release` — same output as the **Generate release notes** button in the GitHub UI: merged PR titles with authors, new contributors, and a *Full Changelog* compare link, for everything between the previous tag and this one.
- `.github/release.yml` — GitHub's config for those notes. Excludes PRs authored by `dependabot` and `github-actions` (the tagpr release PR itself) so the list is only human changes. Single *Changes* category; labels can be added later to split it (e.g. `enhancement` / `bug`).

## Why this over alternatives
- tagpr's own `releaseNoteCommand` / a custom script: same result, more to maintain.
- `body_path` from CHANGELOG.md: tagpr's changelog already lists PR titles, but without authors/links and it would duplicate what GitHub does for free.

Takes effect on the next release (merge of the tagpr PR).

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8