### PR TITLE
chore: use flat 7-day cooldown for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,10 @@ updates:
       time: "03:00"
       timezone: Asia/Tokyo
     # Security updates bypass cooldown and arrive as soon as an advisory is published.
-    # Version updates wait for a release to age: patches barely (they rarely break, and
-    # batching them only grows the diff), minors until they have matured.
+    # github-actions does not support per-semver cooldown (semver-*-days are ignored and
+    # Dependabot silently falls back to its 3-day default), so use a flat one-week cooldown.
     cooldown:
-      semver-patch-days: 7
-      semver-minor-days: 30
-      semver-major-days: 60
+      default-days: 7
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
Dependabot's `semver-major-days` / `semver-minor-days` / `semver-patch-days` cooldown keys are **not supported for the `github-actions` ecosystem** (only `default-days` is). Per the [options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--), the semver-specific keys are marked unsupported for GitHub Actions, Docker, Terraform, etc.

So the previous block was silently ignored and GitHub Actions updates were effectively running on Dependabot's built-in 3-day default cooldown.

This switches the `github-actions` entry to a flat `default-days: 7`. The `npm` entry is unchanged.

https://claude.ai/code/session_014XFDbztEAigFq4LDTSVCku
